### PR TITLE
修改百度Kafka服务器端口，以及增加log以方便排错。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,12 @@
             <artifactId>kafka-clients</artifactId>
             <version>0.9.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
+        </dependency>
     </dependencies>
+
     <name>kafka-sample-java</name>
 </project>

--- a/run.bat
+++ b/run.bat
@@ -3,5 +3,5 @@
 echo compile...
 
 mvn -q clean compile exec:java^
- -Dexec.mainClass="com.baidu.cloud.kafka.samples.Application"^
+ -Dexec.mainClass="com.baidu.cloud.kafka.Application"^
  -Dexec.args="%1"

--- a/run.sh
+++ b/run.sh
@@ -3,5 +3,5 @@
 echo compile...
 
 mvn -q clean compile exec:java \
- -Dexec.mainClass="com.baidubce.kafka.samples.Application" \
+ -Dexec.mainClass="com.baidu.cloud.kafka.Application" \
  -Dexec.args="$1"

--- a/src/main/java/com/baidu/cloud/kafka/Consumer.java
+++ b/src/main/java/com/baidu/cloud/kafka/Consumer.java
@@ -30,15 +30,19 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class Consumer {
+
+    private static final Logger logger = LoggerFactory.getLogger(Consumer.class);
 
     private static final int TIME_OUT_MS = 5000;
 
     static void run(String topic, int numOfRecords) throws IOException {
         Properties properties = new Properties();
         properties.load(Consumer.class.getClassLoader().getResourceAsStream("client.properties"));
-        properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "kafka.bj.baidubce.com:9092");
+        properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "kafka.bj.baidubce.com:9091");
         properties.setProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "kafka-samples-java-consumer");
         properties.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "kafka-samples-java-group");
         properties.setProperty(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
@@ -53,7 +57,7 @@ class Consumer {
                 String position = record.partition() + "-" + record.offset();
                 String key = new String(record.key(), "UTF-8");
                 String value = new String(record.value(), "UTF-8");
-                System.out.println(position + ": " + key + " " + value);
+                logger.info(position + ": " + key + " " + value);
             }
             numOfRecords -= records.count();
         }

--- a/src/main/java/com/baidu/cloud/kafka/Producer.java
+++ b/src/main/java/com/baidu/cloud/kafka/Producer.java
@@ -34,7 +34,7 @@ class Producer {
     static void run(String topic, int numOfRecords) throws IOException {
         Properties properties = new Properties();
         properties.load(Consumer.class.getClassLoader().getResourceAsStream("client.properties"));
-        properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "kafka.bj.baidubce.com:9092");
+        properties.setProperty(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "kafka.bj.baidubce.com:9091");
         properties.setProperty(CommonClientConfigs.CLIENT_ID_CONFIG, "kafka-samples-java-producer");
         properties.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
         properties.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,4 @@
+#config root logger  
+log4j.rootLogger = INFO,system.out  
+log4j.appender.system.out=org.apache.log4j.ConsoleAppender  
+log4j.appender.system.out.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
GitHub上代码已经不同步，最典型的问题是目前BJ的Kafka服务端口已经修改成9091，但是GitHub上的端口仍然是9092。此外调试信息也不方便，一并修改。